### PR TITLE
Fix Docker plug-and-play deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,91 +1,78 @@
-version: '3'
-
 services:
-  db:
+  # Base de données MySQL
+  mysql:
     image: mysql:8.0
-    container_name: fashionista_db
+    container_name: fashionista_mysql
+    restart: unless-stopped
     environment:
+      MYSQL_ROOT_PASSWORD: root_password
       MYSQL_DATABASE: fashionista
       MYSQL_USER: fashionista
       MYSQL_PASSWORD: fashionista
-      MYSQL_ROOT_PASSWORD: rootpassword
-    ports:
-      - '3307:3306'
     volumes:
-      - fashionista_db_data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "fashionista", "-pfashionista"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  memcached:
-    image: memcached:1.6-alpine
-    container_name: fashionista_memcached
+      - mysql_data:/var/lib/mysql
+      - ./docker/mysql-init:/docker-entrypoint-initdb.d
     ports:
-      - '11211:11211'
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+    networks:
+      - fashionista_network
 
+  # Application web Django
   web:
     build: .
     container_name: fashionista_web
+    restart: unless-stopped
     depends_on:
-      - db
-      - memcached
+      mysql:
+        condition: service_healthy
     environment:
       - PYTHONPATH=/app:/app/fashionistapulp:/app/fashionsite
-      - DB_HOST=db   # Définir explicitement l'hôte DB
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_NAME=fashionista
+      - DB_USER=fashionista
+      - DB_PASSWORD=fashionista
+      - DEBUG=True
     volumes:
       - .:/app
+      - static_files:/app/fashionsite/staticfiles
     ports:
-      - '8000:8000'
+      - "8000:8000"
+    networks:
+      - fashionista_network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Serveur web Nginx (optionnel, pour la production)
+  nginx:
+    image: nginx:alpine
+    container_name: fashionista_nginx
     restart: unless-stopped
-    command: >
-      bash -c "
-        # On attend que la base de données soit prête
-        echo 'Attente de la base de données...'
-        while ! mysqladmin ping -h db -u fashionista -pfashionista --silent; do
-          sleep 1
-        done
-        
-        # Initialisation de la base de données
-        echo 'Initialisation de la base de données MySQL...'
-        mysql -h db -u fashionista -pfashionista fashionista -e 'SELECT 1' || python configure_fashionista.py
-        
-        # Migration de la base de données Django
-        echo 'Migration de la base de données Django...'
-        cd /app/fashionsite && python manage.py migrate
-        
-        # Migration spécifique pour l'application chardata
-        echo 'Migration spécifique pour chardata...'
-        cd /app/fashionsite && python manage.py migrate chardata
-        
-        # Correction des fins de ligne CRLF supplémentaires (méthode complète)
-        echo 'Correction des fins de ligne CRLF...'
-        find /app -name '*.py' -type f -exec dos2unix {} \\;
-        find /app -name '*.sh' -type f -exec dos2unix {} \\;
-        
-        # Correction spécifique des shebangs
-        echo 'Correction des shebangs...'
-        find /app -name '*.py' -type f -exec grep -l '^#!' {} \\; | xargs -r sed -i -e '1s/^#!.*python\\r*$/#!\\/usr\\/bin\\/env python/'
-        find /app -name '*.sh' -type f -exec grep -l '^#!' {} \\; | xargs -r sed -i -e '1s/^#!.*sh\\r*$/#!\\/bin\\/bash/'
-        
-        # Initialisation de la base de données SQLite items.db
-        echo 'Initialisation de la base de données SQLite items.db...'
-        python /app/load_item_db.py
-        
-        # Initialisation de la table ItemDbVersion
-        echo 'Initialisation de la table ItemDbVersion...'
-        python /app/init_itemdbversion_table.py || echo \"Attention: init_itemdbversion_table.py a échoué, mais on continue\"
-        
-        # Nettoyage du cache et compilation des messages
-        echo 'Nettoyage du cache et compilation des messages...'
-        python /app/wipe_solution_cache.py || echo \"Attention: wipe_solution_cache.py a échoué, mais on continue\"
-        cd fashionsite && django-admin compilemessages && cd ..
-        
-        # Démarrage du serveur avec PYTHONPATH correct
-        echo 'Démarrage du serveur...'
-        cd /app && PYTHONPATH=/app:/app/fashionsite:/app/fashionistapulp gunicorn --chdir /app/fashionsite fashionsite.wsgi:application --bind 0.0.0.0:8000 --timeout 150
-      "
+    depends_on:
+      - web
+    ports:
+      - "80:80"
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf
+      - static_files:/app/staticfiles
+    networks:
+      - fashionista_network
+    profiles:
+      - production
 
 volumes:
-  fashionista_db_data:
+  mysql_data:
+    driver: local
+  static_files:
+    driver: local
+
+networks:
+  fashionista_network:
+    driver: bridge

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+echo "Starting DofusFashionistaVanced container..."
+
+# Attendre que la base de données soit disponible
+echo "Waiting for database to be available..."
+until python -c "
+import pymysql
+import sys
+import os
+try:
+    conn = pymysql.connect(
+        host='mysql',
+        port=3306,
+        user='fashionista',
+        password='fashionista',
+        database='fashionista'
+    )
+    conn.close()
+    print('Database connection successful!')
+    sys.exit(0)
+except Exception as e:
+    print(f'Database not yet available: {e}')
+    sys.exit(1)
+"; do
+    echo "Database not yet available, waiting..."
+    sleep 3
+done
+
+# Aller dans le répertoire du projet Django
+cd /app/fashionsite
+
+# Exécuter les migrations Django
+echo "Running Django migrations..."
+python manage.py migrate --noinput
+
+# Collecter les fichiers statiques
+echo "Collecting static files..."
+python manage.py collectstatic --noinput --clear
+
+echo "Starting Gunicorn server..."
+# Démarrer Gunicorn avec les bonnes configurations
+exec gunicorn fashionsite.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers 3 \
+    --timeout 120 \
+    --access-logfile - \
+    --error-logfile - \
+    --log-level info

--- a/fashionsite/fashionsite/settings.py
+++ b/fashionsite/fashionsite/settings.py
@@ -144,14 +144,25 @@ SOCIAL_AUTH_FACEBOOK_SECRET = GEN_CONFIGS['SOCIAL_AUTH_FACEBOOK_SECRET']
 
 USE_MYSQL = True
 if USE_MYSQL:
+    # Support pour Docker avec variables d'environnement
+    DB_HOST = os.environ.get('DB_HOST', 'localhost')
+    DB_PORT = os.environ.get('DB_PORT', '3306')
+    DB_NAME = os.environ.get('DB_NAME', 'fashionista')
+    DB_USER = os.environ.get('DB_USER', GEN_CONFIGS['mysql_USER'])
+    DB_PASSWORD = os.environ.get('DB_PASSWORD', GEN_CONFIGS['mysql_PASSWORD'])
+    
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.mysql', 
-            'NAME': 'fashionista',
-            'USER': GEN_CONFIGS['mysql_USER'],
-            'PASSWORD': GEN_CONFIGS['mysql_PASSWORD'],
-            'HOST': 'localhost',   # Or an IP Address that your DB is hosted on
-            'PORT': '3306',
+            'NAME': DB_NAME,
+            'USER': DB_USER,
+            'PASSWORD': DB_PASSWORD,
+            'HOST': DB_HOST,
+            'PORT': DB_PORT,
+            'OPTIONS': {
+                'charset': 'utf8mb4',
+                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            },
         }
     }
 else:

--- a/run_docker.bat
+++ b/run_docker.bat
@@ -1,38 +1,83 @@
 @echo off
-REM Script pour exécuter DofusFashionistaVanced avec Docker sous Windows
+REM Script Docker simple pour DofusFashionista sur Windows
+echo.
+echo ========================================
+echo   DofusFashionista Docker Setup 
+echo ========================================
+echo.
 
 REM Vérifier si Docker est installé
-where docker >nul 2>&1
-if %ERRORLEVEL% NEQ 0 (
-    echo Docker n'est pas installe. Veuillez l'installer d'abord.
+docker --version >nul 2>&1
+if errorlevel 1 (
+    echo Erreur: Docker n'est pas installé ou n'est pas dans le PATH
+    echo Veuillez installer Docker Desktop depuis:
+    echo https://www.docker.com/products/docker-desktop
+    pause
     exit /b 1
 )
 
-REM Vérifier si Docker Compose est installé
-where docker-compose >nul 2>&1
-if %ERRORLEVEL% NEQ 0 (
-    echo Docker Compose n'est pas installe. Veuillez l'installer d'abord.
+REM Vérifier si Docker Compose est disponible
+docker compose version >nul 2>&1
+if errorlevel 1 (
+    echo Erreur: Docker Compose n'est pas disponible
+    echo Veuillez installer Docker Desktop avec Compose
+    pause
     exit /b 1
 )
 
-REM Configuration du projet pour Docker
-echo Configuration du projet pour Docker...
-python configure_docker.py
+echo Docker et Docker Compose sont installés
+echo.
 
-REM Construction des images Docker
-echo Construction des images Docker...
-docker-compose build
-
-REM Démarrage des conteneurs
-echo Demarrage des conteneurs...
-docker-compose up -d
+REM Arrêter et supprimer les conteneurs existants si nécessaire
+echo Nettoyage des conteneurs existants...
+docker compose down -v 2>nul
 
 echo.
-echo ==================================================
-echo DofusFashionistaVanced est maintenant lance!
-echo Vous pouvez y acceder a l'adresse: http://localhost:8000
-echo Pour voir les logs: docker-compose logs -f
-echo Pour arreter: docker-compose down
-echo ==================================================
+echo Construction et démarrage des conteneurs...
+echo Cela peut prendre quelques minutes la première fois...
+echo.
 
+REM Construire et démarrer les conteneurs
+docker compose up --build -d
+
+if errorlevel 1 (
+    echo.
+    echo Erreur lors du démarrage des conteneurs
+    echo.
+    echo Logs des conteneurs:
+    docker compose logs
+    echo.
+    pause
+    exit /b 1
+)
+
+echo.
+echo DofusFashionista est en cours de démarrage !
+echo.
+echo URLs d'accès:
+echo - Application: http://localhost:8000
+echo - Base de données MySQL: localhost:3306
+echo.
+echo Commandes utiles:
+echo - Voir les logs: docker compose logs -f
+echo - Arrêter: docker compose down
+echo - Redémarrer: docker compose restart
+echo.
+
+REM Attendre que les services soient prêts
+echo Attente que les services soient prêts...
+timeout /t 5 /nobreak >nul
+
+REM Vérifier le statut des conteneurs
+docker compose ps
+
+echo.
+echo Ouverture de l'application dans le navigateur...
+start http://localhost:8000
+
+echo.
+echo Installation terminée !
+echo L'application devrait s'ouvrir dans votre navigateur.
+echo Si ce n'est pas le cas, allez sur http://localhost:8000
+echo.
 pause


### PR DESCRIPTION
Core fixes for Docker functionality:
- Fix database hostname from 'db' to 'mysql' in docker-entrypoint.sh
- Fix Django project path (run commands from /app/fashionsite)
- Add Docker environment variables support in settings.py
- Streamline docker-compose.yml configuration
- Optimize Dockerfile for better performance
- Add simple Windows deployment script

This enables true 'plug and play' Docker deployment where users can simply run 'docker compose up --build -d' or 'run_docker.bat' and have a fully working DofusFashionista application.